### PR TITLE
Minimal install of psrdada

### DIFF
--- a/packages/psrdada/no_cuda_no_mopsr.patch
+++ b/packages/psrdada/no_cuda_no_mopsr.patch
@@ -1,0 +1,14 @@
+--- a/mopsr/Makefile.am	2018-06-13 16:21:51.000000000 +0200
++++ b/mopsr/Makefile.am	2018-06-13 16:37:25.097848118 +0200
+@@ -2,9 +2,10 @@
+ SUBDIRS = scripts config
+ 
+ # source code for mopsr heavily dependent on PGPLOT and FFTW3
++if HAVE_CUDA
+ if HAVE_PGPLOT
+ if HAVE_FFTW3
+   SUBDIRS += src
+ endif
+ endif
+-
++endif

--- a/packages/psrdada/package.py
+++ b/packages/psrdada/package.py
@@ -12,26 +12,36 @@ class Psrdada(AutotoolsPackage):
     version('2018-06-06', git='https://git.code.sf.net/p/psrdada/code',
             commit='754a618b321cf0b328d34c80c995ad0959ddf4e8')
 
+    variant('cuda', default=True, description='Enable CUDA support.')
+    variant('hwloc', default=True, description='Enable hwloc support.')
+    variant('gsl', default=True, description='Enable gsl support.')
+    variant('fftw', default=True, description='Enable FFTW support.')
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
 
-    depends_on('cuda')
-    depends_on('fftw@3.3:')
-    depends_on('gsl')
-    depends_on('hwloc')
+    depends_on('cuda', when='+cuda')
+    depends_on('hwloc', when='+hwloc')
+    depends_on('gsl', when='+gsl')
+    depends_on('fftw@3.3', when='+mpi')
 
     patch('fix_pragma.patch', level=1)
+    patch('no_cuda_no_mopsr.patch', level=1)
     patch('missing_cuda_include.patch', level=1)
 
     def autoreconf(self, spec, prefix):
         autoreconf('--install', '--force')
 
     def configure_args(self):
-        args = ['--with-cuda-dir=%s' % self.spec['cuda'].prefix,
-                '--with-fftw3-dir=%s' % self.spec['fftw'].prefix,
-                '--with-gsl-dir=%s' % self.spec['gsl'].prefix,
-                '--with-hwloc-dir=%s' % self.spec['hwloc'].prefix]
+        args = []
+        if 'fftw' in self.spec:
+            args.push('--with-fftw3-dir=%s' % self.spec['fftw'].prefix)
+        if 'gsl' in self.spec:
+            args.push('--with-gsl-dir=%s' % self.spec['gsl'].prefix)
+        if 'cuda' in self.spec:
+            args.push('--with-cuda-dir=%s' % self.spec['cuda'].prefix)
+        if 'hwloc' in self.spec:
+            args.push('--with-hwloc-dir=%s' % self.spec['hwloc'].prefix)
         return args


### PR DESCRIPTION
I modified the psrdada package to provide a minimal (little dependencies) build.
```
spack install psrdada -fftw -gsl -cuda -hwloc
```
this is really useful for developing our pipeline, and we're only using the ringbuffer code.