### PR TITLE
Add heimdall dependencies

### DIFF
--- a/packages/heimdall-astro/package.py
+++ b/packages/heimdall-astro/package.py
@@ -18,6 +18,9 @@ class HeimdallAstro(AutotoolsPackage):
     depends_on('cuda')
     depends_on('dedisp-flexi')
     depends_on('psrdada')
+    depends_on('gsl')
+    depends_on('hwloc')
+    depends_on('fftw')
     
     def configure_args(self):
         args = []


### PR DESCRIPTION
I was getting errors on ARTS unless these three dependencies are added. Not sure why it needs hwloc and gsl though.